### PR TITLE
Set default for the Public Key comment to string

### DIFF
--- a/src/sshkey_tools/keys.py
+++ b/src/sshkey_tools/keys.py
@@ -117,7 +117,7 @@ class PublicKey:
     """
 
     def __init__(
-        self, key: PrivkeyClasses = None, comment: Union[str, bytes] = None, **kwargs
+        self, key: PrivkeyClasses = None, comment: Union[str, bytes] = "", **kwargs
     ) -> None:
         self.key = key
         self.comment = comment


### PR DESCRIPTION
Set the default for the Public Key comment to an empty string instead of None to avoid forcing users to set the comment manually when exporting to string/file

Resolves #13 