### PR TITLE
Convert nonce field to bytestring

### DIFF
--- a/src/sshkey_tools/fields.py
+++ b/src/sshkey_tools/fields.py
@@ -471,7 +471,7 @@ class DateTimeField(Integer64Field):
             if value == "forever":
                 return Integer64Field.encode(MAX_INT64 - 1)
 
-            value = int(datetime.now() + str_to_time_delta(value))
+            value = int((datetime.now() + str_to_time_delta(value)).timestamp())
 
         if isinstance(value, datetime):
             value = int(value.timestamp())

--- a/src/sshkey_tools/fields.py
+++ b/src/sshkey_tools/fields.py
@@ -265,7 +265,7 @@ class BytestringField(CertificateField):
     DEFAULT = b""
 
     @classmethod
-    def encode(cls, value: bytes, encoding: str = 'utf-8') -> bytes:
+    def encode(cls, value: bytes, encoding: str = "utf-8") -> bytes:
         """
         Encodes a string or bytestring into a packed byte string
 
@@ -293,7 +293,7 @@ class BytestringField(CertificateField):
                                   string and remainder of the data
         """
         length = unpack(">I", data[:4])[0] + 4
-        
+
         if encoding is not None:
             return ensure_string(data[4:length], encoding), data[length:]
 
@@ -335,6 +335,7 @@ class StringField(BytestringField):
                                   string and remainder of the data
         """
         return BytestringField.decode(data, encoding)
+
 
 class Integer32Field(CertificateField):
     """

--- a/src/sshkey_tools/utils.py
+++ b/src/sshkey_tools/utils.py
@@ -304,4 +304,6 @@ def str_to_time_delta(str_delta: str) -> datetime.timedelta:
         parsed = time_parse(str_delta, as_timedelta=True, raise_exception=True)
         return parsed
     except Exception as ex:
-        raise ValueError(f"Could not parse time delta string {str_delta} : {ex}") from ex
+        raise ValueError(
+            f"Could not parse time delta string {str_delta} : {ex}"
+        ) from ex


### PR DESCRIPTION
Converts the nonce field to bytestring to avoid decoding errors when nonce is a non-utf8 bytestring

Resolves #19 