### PR TITLE
Update `requirements.txt` to unblock Cryptography 43.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click~=8.1
-cryptography~=42.0.7
+cryptography>=42.0,<44
 bcrypt~=4.2
 PrettyTable~=3.9
 pytimeparse2~=1.1


### PR DESCRIPTION
Unblock Cryptography 43.x given it is now fully tested, otherwise users are forced to use 42.0.x.